### PR TITLE
`supportedMethods` is not an array anymore

### DIFF
--- a/app/scripts/features.js
+++ b/app/scripts/features.js
@@ -3065,7 +3065,7 @@ function initPaymentRequest() {
   let networks = ['amex', 'jcb', 'visa'];
   
   let supportedInstruments = [{
-    supportedMethods: ['basic-card'],
+    supportedMethods: 'basic-card',
     data: {
       supportedNetworks: networks, 
       supportedTypes: ['debit', 'credit', 'prepaid']


### PR DESCRIPTION
As per the [Payment Request API specification](https://w3c.github.io/payment-request/#paymentmethoddata-dictionary), `supportedMethods` is now just a `DOMString` and not an array anymore.